### PR TITLE
fix: Objective-C utility creation is ruined due to incorrect parameter

### DIFF
--- a/Nyxian/UI/ContentView.swift
+++ b/Nyxian/UI/ContentView.swift
@@ -65,7 +65,7 @@ import UIKit
         
         let ObjCCUtility: UIAction = UIAction(title: "ObjC") { [weak self] _ in
             guard let self = self else { return }
-            self.createProject(mode: .utility, withLanguage: .C)
+            self.createProject(mode: .utility, withLanguage: .objC)
         }
         
         let utilityMenu: UIMenu = UIMenu(title: "Utility", image: UIImage(systemName: "wrench.adjustable.fill"), children: [CUtility, CPPCUtility, ObjCCUtility])


### PR DESCRIPTION
When I create the utility project with Objective-C, I can’t get the proper project template. I always get a template for C. And I find that createProject uses ‘.C’ even for the ObjC.